### PR TITLE
Gan contact form

### DIFF
--- a/2015/about.html
+++ b/2015/about.html
@@ -39,7 +39,7 @@
           </li>
           <li class="active">
             <a href="/2015/about.html">About</a>
-          </li><!-- <li><a href="/2015/contact.html">Contact Us</a></li> -->
+          </li><li><a href="/2015/contact.html">Contact Us</a></li>
           <li>
             <a class="btn" href="http://www.readydayone.com">SIGN IN</a>
           </li>
@@ -101,7 +101,7 @@
         <hr>
         <h3>Request Our White Papers</h3>Cornerstone is professionally committed to creating effective, research-based solutions to our clients’ need to identify and prepare top talent to become effective leaders and managers. Our system is based on peer-reviewed, published research and on basic statistical principles universally recognized as tools for studying and evaluating this type of material. This approach protects organizations from investing in programs that appear effective but do not pass the test of time.<br>
         <br>
-        To learn more about why we do what we do and how we are different from (and more effective than) traditional assessment centers, <a href="/home/contact">click here</a> to request a copy of our white papers:<br>
+        To learn more about why we do what we do and how we are different from (and more effective than) traditional assessment centers, <a href="/home/contact.html">click here</a> to request a copy of our white papers:<br>
         <br>
         <i class="fa fa-file-o"></i>&nbsp;<span style="font-style:italic; font-weight: bold">Why We Are Different</span><br>
         <i class="fa fa-file-o"></i>&nbsp;<span style="font-style:italic; font-weight: bold">Much, Much More Than Your Father's Assessment Center</span>
@@ -188,7 +188,7 @@
             <div class="widget-body">
               <p>Phone: (412) 429-6400<br>
               Fax: (412) 429-6450<br>
-              <a href="mailto:#">contact@leadwithcornerstone.com</a><br>
+              <!-- <a href="mailto:#">contact@leadwithcornerstone.com</a><br> -->
               <br>
               212 Mary Street, Carnegie, PA 15106</p>
             </div>
@@ -217,7 +217,7 @@
         <div class="row">
           <div class="col-md-6 widget">
             <div class="widget-body">
-              <p class="simplenav"><a href="#">Home</a> | <a href="/2015/approach.html">Our Approach</a> | <a href="/2015/meet.html">Meet the Team</a> | <a href="/2015/about.html">About</a> | <!-- <a href="/2015/contact.html">Contact</a> --></p>
+              <p class="simplenav"><a href="#">Home</a> | <a href="/2015/approach.html">Our Approach</a> | <a href="/2015/meet.html">Meet the Team</a> | <a href="/2015/about.html">About</a> | <a href="/2015/contact.html">Contact</a></p>
             </div>
           </div>
           <div class="col-md-6 widget">

--- a/2015/about.html
+++ b/2015/about.html
@@ -101,7 +101,7 @@
         <hr>
         <h3>Request Our White Papers</h3>Cornerstone is professionally committed to creating effective, research-based solutions to our clients’ need to identify and prepare top talent to become effective leaders and managers. Our system is based on peer-reviewed, published research and on basic statistical principles universally recognized as tools for studying and evaluating this type of material. This approach protects organizations from investing in programs that appear effective but do not pass the test of time.<br>
         <br>
-        To learn more about why we do what we do and how we are different from (and more effective than) traditional assessment centers, <a href="/home/contact.html">click here</a> to request a copy of our white papers:<br>
+        To learn more about why we do what we do and how we are different from (and more effective than) traditional assessment centers, <a href="/2015/contact.html">click here</a> to request a copy of our white papers:<br>
         <br>
         <i class="fa fa-file-o"></i>&nbsp;<span style="font-style:italic; font-weight: bold">Why We Are Different</span><br>
         <i class="fa fa-file-o"></i>&nbsp;<span style="font-style:italic; font-weight: bold">Much, Much More Than Your Father's Assessment Center</span>

--- a/2015/approach.html
+++ b/2015/approach.html
@@ -37,7 +37,7 @@
           </li>
           <li>
             <a href="/2015/about.html">About</a>
-          </li><!-- <li><a href="/2015/contact.html">Contact Us</a></li> -->
+          </li><li><a href="/2015/contact.html">Contact Us</a></li>
           <li>
             <a class="btn" href="http://www.readydayone.com">SIGN IN</a>
           </li>
@@ -154,7 +154,7 @@
             <div class="widget-body">
               <p>Phone: (412) 429-6400<br>
               Fax: (412) 429-6450<br>
-              <a href="mailto:#">contact@leadwithcornerstone.com</a><br>
+              <!-- <a href="mailto:#">contact@leadwithcornerstone.com</a><br> -->
               <br>
               212 Mary Street, Carnegie, PA 15106</p>
             </div>
@@ -183,7 +183,7 @@
         <div class="row">
           <div class="col-md-6 widget">
             <div class="widget-body">
-              <p class="simplenav"><a href="/2015">Home</a> | <a href="/2015/approach.html">Our Approach</a> | <a href="/2015/meet.html">Meet the Team</a> | <a href="/2015/about.html">About</a> | <!-- <a href="/2015/contact.html">Contact</a> --></p>
+              <p class="simplenav"><a href="/2015">Home</a> | <a href="/2015/approach.html">Our Approach</a> | <a href="/2015/meet.html">Meet the Team</a> | <a href="/2015/about.html">About</a> | <a href="/2015/contact.html">Contact</a></p>
             </div>
           </div>
           <div class="col-md-6 widget">

--- a/2015/contact.html
+++ b/2015/contact.html
@@ -66,9 +66,9 @@
 				<p>
 					If you would like to know more about our process, interested in partnering with us, or would like to request our White Papers, please complete the form below.
 				</p>
-                
+
             <form action="http://remailer.savvysoftworks.com" method="post" >
-                <input type="hidden" name="public_token" value="7e847d4468bcd3562ac3401b4ae576eeb483f72be648df9c37a81fa54e60ef09"/>
+                <input type="hidden" name="public_token" value=""/>
                 <input type="hidden" name="after_success" value="http://leadwithcornerstone.com/index.html"/>
                 <input type="hidden" name="after_failure" value="http://leadwithcornerstone.com/index.html"/>
           				<br>

--- a/2015/contact.html
+++ b/2015/contact.html
@@ -66,8 +66,11 @@
 				<p>
 					If you would like to know more about our process, interested in partnering with us, or would like to request our White Papers, please complete the form below.
 				</p>
-
-            <form action="https://readydayone.com/home/send" method="post" >
+                
+            <form action="http://remailer.savvysoftworks.com" method="post" >
+                <input type="hidden" name="public_token" value="7e847d4468bcd3562ac3401b4ae576eeb483f72be648df9c37a81fa54e60ef09"/>
+                <input type="hidden" name="after_success" value="http://leadwithcornerstone.com/index.html"/>
+                <input type="hidden" name="after_failure" value="http://leadwithcornerstone.com/index.html"/>
           				<br>
 
 						<div class="row">

--- a/2015/contact.html
+++ b/2015/contact.html
@@ -68,7 +68,7 @@
 				</p>
 
             <form action="http://remailer.savvysoftworks.com" method="post" >
-                <input type="hidden" name="public_token" value=""/>
+                <input type="hidden" name="public_token" value="a2277d710e38c0275b4038196d1fec3479126b0d4868f03f812acbb3d9810c64"/>
                 <input type="hidden" name="after_success" value="http://leadwithcornerstone.com/index.html"/>
                 <input type="hidden" name="after_failure" value="http://leadwithcornerstone.com/index.html"/>
           				<br>

--- a/2015/index.html
+++ b/2015/index.html
@@ -37,7 +37,7 @@
           </li>
           <li>
             <a href="/2015/about.html">About</a>
-          </li><!--<li><a href="/2015/contact.html">Contact Us</a></li> -->
+          </li><li><a href="/2015/contact.html">Contact Us</a></li> 
           <li>
             <a class="btn" href="http://www.readydayone.com">SIGN IN</a>
           </li>
@@ -113,7 +113,7 @@
             <div class="widget-body">
               <p>Phone: (412) 429-6400<br>
               Fax: (412) 429-6450<br>
-              <a href="mailto:#">contact@leadwithcornerstone.com</a><br>
+              <!-- <a href="mailto:#">contact@leadwithcornerstone.com</a><br> -->
               <br>
               212 Mary Street, Carnegie, PA 15106</p>
             </div>
@@ -142,7 +142,7 @@
         <div class="row">
           <div class="col-md-6 widget">
             <div class="widget-body">
-              <p class="simplenav"><a href="#">Home</a> | <a href="/2015/approach.html">Our Approach</a> | <a href="/2015/meet.html">Meet the Team</a> | <a href="/2015/about.html">About</a> | <!-- <a href="//2015/contact.html">Contact</a> --></p>
+              <p class="simplenav"><a href="#">Home</a> | <a href="/2015/approach.html">Our Approach</a> | <a href="/2015/meet.html">Meet the Team</a> | <a href="/2015/about.html">About</a> | <a href="//2015/contact.html">Contact</a></p>
             </div>
           </div>
           <div class="col-md-6 widget">

--- a/2015/meet.html
+++ b/2015/meet.html
@@ -35,7 +35,7 @@
             <li><a href="/2015/approach.html">Our Approach</a></li>
             <li class="active"><a href="/2015/meet.html">Meet the Team</a></li>
             <li><a href="/2015/about.html">About</a></li>
-            <!-- <li><a href="/2015/contact.html">Contact Us</a></li> -->
+            <li><a href="/2015/contact.html">Contact Us</a></li>
             <li><a class="btn" href="http://www.readydayone.com">SIGN IN</a></li>
           </ul>
         </div>
@@ -295,7 +295,7 @@
               <div class="widget-body">
                 <p>Phone: (412) 429-6400
                   <br>Fax: (412) 429-6450<br>
-                  <a href="mailto:#">contact@leadwithcornerstone.com</a><br>
+                  <!-- <a href="mailto:#">contact@leadwithcornerstone.com</a><br> -->
                   <br>
                   212 Mary Street, Carnegie, PA 15106
                 </p>
@@ -337,7 +337,7 @@
                   <a href="/2015/approach.html">Our Approach</a> |
                   <a href="/2015/meet.html">Meet the Team</a> |
                   <a href="/2015/about.html">About</a> |
-                  <!-- <a href="/2015/contact.html">Contact</a> -->
+                  <a href="/2015/contact.html">Contact</a>
                 </p>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             <li><a href="/2015/approach.html">Our Approach</a></li>
             <li><a href="/2015/meet.html">Meet the Team</a></li>
             <li><a href="/2015/about.html">About</a></li>
-            <!-- <li><a href="/2015/contact.html">Contact Us</a></li> -->
+            <li><a href="/2015/contact.html">Contact Us</a></li>
             <li><a class="btn" href="http://www.readydayone.com">SIGN IN</a></li>
           </ul>
         </div>
@@ -146,7 +146,7 @@
               <div class="widget-body">
                 <p>Phone: (412) 429-6400
                   <br>Fax: (412) 429-6450<br>
-                  <a href="mailto:#">contact@leadwithcornerstone.com</a><br>
+                  <!-- <a href="mailto:#">contact@leadwithcornerstone.com</a><br> -->
                   <br>
                   212 Mary Street, Carnegie, PA 15106
                 </p>
@@ -188,7 +188,7 @@
                   <a href="/2015/approach.html">Our Approach</a> |
                   <a href="/2015/meet.html">Meet the Team</a> |
                   <a href="/2015/about.html">About</a> |
-                  <!-- <a href="/2015/contact.html">Contact</a> -->
+                  <a href="/2015/contact.html">Contact</a>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
###### Dependencies:

Will depend on `savvy_mailer`
###### Fixes:

Broken contact links
- Re-install `Contact` links
- Re-direct broken `Contact` link on `About` page
- Direct contact form to `savvy_mailer`

Un-commented out links to `Contact` page and fixed the broken link on the `About` page. Removed `mailto` links from bottom of all pages. Installed the calls to `savvy_mailer` minus the `public token`
###### For review
- Contact form
- calls to `savvy_mailer`
