### PR TITLE
Fixes for issues 15, 17, 18

### DIFF
--- a/data/team.yaml
+++ b/data/team.yaml
@@ -8,7 +8,7 @@ our_team:
     name: "Carl Thoresen, Ph.D."
     position: "President"
     image: "/images/carl.jpg"
-    about: "Carl joined the Cornerstone team after working as Assistant Professor of industrial/organizational psychology at Tulane University. As an internationally recognized author and researcher on employee selection, job attitudes, employee assessment, and the role of personality in job performance, Carl brings a unique, research-oriented perspective to the design and implementation of Cornerstone’s programs. He has extensive training and experience in test development and validation.After graduating from Northwestern University, Carl earned an M.S. degree in organizational behavior from Cornell University. He later completed his Ph.D. in human resource management with a minor concentration in personality and social psychology at the University of Iowa."
+    about: "Carl joined the Cornerstone team after working as Assistant Professor of industrial/organizational psychology at Tulane University. As an internationally recognized author and researcher on employee selection, job attitudes, employee assessment, and the role of personality in job performance, Carl brings a unique, research-oriented perspective to the design and implementation of Cornerstone’s programs. He has extensive training and experience in test development and validation. After graduating from Northwestern University, Carl earned an M.S. degree in organizational behavior from Cornell University. He later completed his Ph.D. in human resource management with a minor concentration in personality and social psychology at the University of Iowa."
   - idn: "003"
     name: "Denise Meyer Kennell, M.S."
     position: "Director of Operations/Client Services"

--- a/source/_footer.html.erb
+++ b/source/_footer.html.erb
@@ -46,7 +46,7 @@
                 <p class="simplenav">
                   <%= link_to 'Home', '/index.html' %> &nbsp;
                   <%= link_to 'Our Approach', '/approach.html' %> &nbsp;
-                  <%= link_to 'Meet the Team', '/meet.html' %> &nbsp;
+                  <%= link_to 'Meet the Team', '/team.html' %> &nbsp;
                   <%= link_to 'About', '/about.html' %> &nbsp;
                   <%= link_to 'Contact Us', '/contact.html' %> &nbsp;
                   <%= link_to 'Ready Day One', '/readydayone.html' %> &nbsp;

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -43,7 +43,7 @@ title: Cornerstone | Meet the Team
               </div>
             </div>
             <div class="modal-body">
-              <p>
+              <p class="text-left">
                 <%= member.about %>
               </p>
             </div>


### PR DESCRIPTION
###### Fixes for issues #15, #17, #18
- Fix `Meet the Team` link in footer
- Fixed missing `space` in Carl copy
- Fix modal justification for body content

Fixed bad link in the footer section, was linking to the old `meet` page, now directs to the new `team` page with modals. Fixed the missing space character in Carl's about section, as well as aligned all body content left inside the modals.
###### Needs CR
###### IF approved needs `rake publish`
