### PR TITLE
Crawl error fix, erroneous meet.html link left behind

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -57,7 +57,7 @@ title: Cornerstone
           <source src="/images/promo.webm">
           Your browser does not support the video tag.
         </video>
-        <span STYLE="font-size: small; color: #000"><a href="/2015/meet.html">Joe Thoresen</a> and <a href="/2015/meet.html">Carl Thoresen</a> explain the Cornerstone Experience.</span><br><br>
+        <span STYLE="font-size: small; color: #000"><a href="/team.html">Joe Thoresen</a> and <a href="/team.html">Carl Thoresen</a> explain the Cornerstone Experience.</span><br><br>
       </div>
       <div class="col-sm-6">
         <h3>Why Choose Cornerstone?</h3>


### PR DESCRIPTION
###### Fix Crawl Error

Discovered through analytics two old `/2015/meet.html` links within the body of the index page. Replaced said offenders with `/team.html`.
###### Needs
- Approval
- `rake publish`
