### PR TITLE
Add padding to top of logo bar

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -14,7 +14,7 @@ title: Cornerstone
 </header>
 <!-- /Header -->
 <!-- Client Logo Bar -->
-<div class="row">
+<div class="row" style="padding-top: 1.5em;">
   <h2 class="text-center">
     <img class="logo_bar" src="/images/client_logos/web/web_janssen.png">
     <img class="logo_bar" src="/images/client_logos/web/web_regeneron.png">


### PR DESCRIPTION
###### Add padding to top of the logo bar on home page - Bugherd #1

Added padding to the top of the log bar on the home page.
- 1.5em padding added
###### Needs
- CR and Approval
- `rake publish`
