### PR TITLE
Gan/press release

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,16 @@ endpose_middleman_helpers = true
 end
 
 activate :blog do |blog|
+  blog.name = 'blog'
   blog.prefix = 'blog'
+  blog.layout = 'blog'
+  blog.sources = "{year}-{month}-{day}-{title}.html"
+  blog.permalink = "{category}/{title}.html"
+end
+
+activate :blog do |blog|
+  blog.name = 'press'
+  blog.prefix = 'press'
   blog.layout = 'blog'
   blog.sources = "{year}-{month}-{day}-{title}.html"
   blog.permalink = "{category}/{title}.html"

--- a/config.rb
+++ b/config.rb
@@ -17,7 +17,7 @@ end
 activate :blog do |blog|
   blog.name = 'press'
   blog.prefix = 'press'
-  blog.layout = 'blog'
+  blog.layout = 'press'
   blog.sources = "{year}-{month}-{day}-{title}.html"
   blog.permalink = "{category}/{title}.html"
 end

--- a/source/blog/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
+++ b/source/blog/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
@@ -1,0 +1,44 @@
+---
+title: Worldwide Business with kathy ireland® Explores Cornerstone’s Approach to Building Great Business Leaders
+date: 2016-11-09 20:46 UTC
+author: Cornerstone Management Resourse Systems
+location: CARNEGIE, Pa.
+category: Press Releases
+tags: Cornerstone, Carl Thorensen, Joe Thorensen, Kathy Ireland
+---
+
+<p>
+  Worldwide Business with kathy ireland® Explores Cornerstone’s Approach to Building Great Business Leaders
+</p>
+<p>
+  Tune in to Fox Business Network as sponsored programming on Saturday, November 26, 2016 and Bloomberg International on Sunday, November 27, 2016, 2016. See market-by-market listings below.
+  Los Angeles, CA – November 23, 2016 — Worldwide Business with kathy ireland® announces an exclusive story featuring, Cornerstone, a company creating effective, research-based solutions to identify and prepare top talent to become effective leaders and managers. 
+</p>
+<p>
+  Cornerstone President, Joe Thoresen and Vice President, Carl Thoresen will explain how they are preparing individuals for their future roles in leadership. 
+  Carl Thoresen says, “The fundamental challenge stems from the fact that when we move people from typically individual roles into frontline leadership roles, especially for the first time, in their careers, we don’t really have a basis for observing how effectively they will perform in that function. So what results is the need to use some sort of interim assessment. We might for example look at performance in a current role or current job, we might have some other methodology that involves some form of testing, etc.”
+</p>
+<p>
+  The company, founded in 1983, was created so that those individuals that are being placed in a position of power have the resources to both learn the role, and learn how to be an effective leader and manager. Cornerstone provides a wide range of e-learning material that helps those individuals go from a place of individual job skills to being able to lead a team and step into the leadership role effectively and efficiently.
+</p>
+<p>
+  “Before people are promoted from individual contributor jobs into first level management positions, they must demonstrate competence handling the key tasks they will have to effectively handle as new managers and leaders,” says Carl Thoresen.  “Performance on simulations, carefully designed to reflect the content of specific first-level management positions and supported with objective measurement techniques, provide the information necessary to make these evaluations. Based on their simulation performance, participants are evaluated on their readiness for promotion. This methodology has been designed to be naturally diagnostic and developmental. When people are evaluated as ‘Not Ready’, they are told what specific tasks/responsibilities they must perform more effectively and provided with developmental ideas and strategies to develop necessary skills.”
+</p>
+<p>
+  Joe Thoresen added, “We provide clients with the option of using a methodology that is much more powerful than the aptitude-based techniques they have used in the past. Although application of our methodology may initially be more complex and expensive than traditional approaches, its accuracy and utility is much more compatible with the short and long term importance of managerial and leadership performance. When promoted, new managers have already demonstrated effectiveness handling key managerial tasks and do not have to engage in on-the-job training to develop the basic skills necessary for success.”
+</p>
+<p>
+  JL Haber, Vice President of Programming for Worldwide Business with kathy ireland®, added. “Cornerstone is providing a much needed and time-tested solution to develop tomorrow’s great business leaders. It is a pleasure to feature them on the show! ”
+</p>
+<p>
+  For more information, visit www.leadwithcornerstone.com and tune in to [Fox Business Network](http://www.foxbusiness.com/channel-finder.html) as sponsored programming on Saturday, November 26, 2016 at 4:30pm EST and [Bloomberg International](http://www.bloomberg.com/tv/schedule/europe/) at 10:00am D.F. and 2:30pm HKT on Sunday November 27, 2016.
+</p>
+<p>
+  About Worldwide Business with kathy ireland®
+</p>
+<p>
+  Worldwide Business with kathy ireland® is a weekly business television program featuring real world insights from corporate executives from all over the globe which can be viewed on Fox Business Network as part of their sponsored programming lineup, as well as internationally to over 50 countries on Bloomberg International. 
+</p>
+<p>
+  Visit [www.tvwwb.com](http://www.tvwwb.com/) for detailed airing schedules or check local listings.
+</p>

--- a/source/blog/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
+++ b/source/blog/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
@@ -31,7 +31,7 @@ tags: Cornerstone, Carl Thorensen, Joe Thorensen, Kathy Ireland
   JL Haber, Vice President of Programming for Worldwide Business with kathy ireland®, added. “Cornerstone is providing a much needed and time-tested solution to develop tomorrow’s great business leaders. It is a pleasure to feature them on the show! ”
 </p>
 <p>
-  For more information, visit www.leadwithcornerstone.com and tune in to [Fox Business Network](http://www.foxbusiness.com/channel-finder.html) as sponsored programming on Saturday, November 26, 2016 at 4:30pm EST and [Bloomberg International](http://www.bloomberg.com/tv/schedule/europe/) at 10:00am D.F. and 2:30pm HKT on Sunday November 27, 2016.
+  For more information, visit www.leadwithcornerstone.com and tune in to <a href="http://www.foxbusiness.com/channel-finder.html">Fox Business Network</a> as sponsored programming on Saturday, November 26, 2016 at 4:30pm EST and <a href="http://www.bloomberg.com/tv/schedule/europe/">Bloomberg International</a> at 10:00am D.F. and 2:30pm HKT on Sunday November 27, 2016.
 </p>
 <p>
   About Worldwide Business with kathy ireland®
@@ -40,5 +40,5 @@ tags: Cornerstone, Carl Thorensen, Joe Thorensen, Kathy Ireland
   Worldwide Business with kathy ireland® is a weekly business television program featuring real world insights from corporate executives from all over the globe which can be viewed on Fox Business Network as part of their sponsored programming lineup, as well as internationally to over 50 countries on Bloomberg International. 
 </p>
 <p>
-  Visit [www.tvwwb.com](http://www.tvwwb.com/) for detailed airing schedules or check local listings.
+  Visit <a href="http://www.tvwwb.com/">www.tvwwb.com</a> for detailed airing schedules or check local listings.
 </p>

--- a/source/blog/2016-11-09-test-blog-post-1.html.markdown
+++ b/source/blog/2016-11-09-test-blog-post-1.html.markdown
@@ -1,0 +1,28 @@
+---
+blog: blog
+title: Dummy Blog Post #1
+date: 2016-11-09 20:46 UTC
+author: Gary A. Newsome
+category: test
+tags: web development, life, business, love, hate
+---
+
+The standard Lorem Ipsum passage, used since the 1500s
+
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+Section 1.10.32 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
+
+1914 translation by H. Rackham
+
+"But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?"
+
+Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat."
+
+1914 translation by H. Rackham
+
+"On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains."

--- a/source/blog/2016-11-09-test-blog-post-2.html.markdown
+++ b/source/blog/2016-11-09-test-blog-post-2.html.markdown
@@ -1,0 +1,28 @@
+---
+blog: blog
+title: Dummy Blog Post #2
+date: 2016-11-09 20:46 UTC
+author: Gary A. Newsome
+category: test
+tags: web development, life, business, love, hate
+---
+
+The standard Lorem Ipsum passage, used since the 1500s
+
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+Section 1.10.32 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
+
+1914 translation by H. Rackham
+
+"But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?"
+
+Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat."
+
+1914 translation by H. Rackham
+
+"On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains."

--- a/source/layouts/press.erb
+++ b/source/layouts/press.erb
@@ -1,0 +1,15 @@
+<% wrap_layout :layout do %>
+  <div class="container blog_container">
+    <div class='row'>
+      <div class='col s12'>
+        <header>
+          <h3 style="padding-top: 2em;"><%= current_article.title %></h3>
+          <p><%= current_article.data.author %>
+        </header>
+        <article>
+          <%= yield %>
+        </article>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/source/news.html.erb
+++ b/source/news.html.erb
@@ -3,41 +3,39 @@ title: Cornerstone | News
 ---
 <div class="blog container" id="blog">
   <div class="blog_column col-sm-12 col-md-8">
-    <h2>News and Updates from Cornerstone</h2>
+    <h3 class="text-center maincontent">NEWS AND UPDATES FROM CORNERSTONE</h3>
     <div class="row">
         <% blog('blog').articles[0...4].each do |article| %>
           <article class="col-sm-12" style="padding-right: 2em;">
-            <h3 class="blog_header">
+            <h3 class="text-left">
               <a href="<%= article.url %>"><%= article.title %></a>
             </h3>
-            <p  style="text-align: center;">
+            <p>
               <time><%= article.date.strftime('%b %e %Y') %></time>
             </p>
 
             <%= article.summary(750, '...') %>
-            <p style ="text-align: center">
-              <a href="<%= article.url %>" style="color: #D40000;">Read more</a>
+            <p>
+              <a href="<%= article.url %>" style="color: #FF7722; padding-top: 0px;">Read more</a>
             </p>
           </article>
         <% end %>
       </div>
   </div>
   <div class="press_release_column col-sm-12 col-md-4">
-    <h2>Press Releases</h2>
+    <h3 class="text-center">PRESS RELEASES</h3>
     <div class="row">
         <% blog('press').articles[0...4].each do |article| %>
           <article class="col-sm-12" style="padding-right: 2em;">
-            <h3 class="blog_header">
-              <a href="<%= article.url %>"><%= article.title %></a>
-            </h3>
-            <p  style="text-align: center;">
-              <time><%= article.date.strftime('%b %e %Y') %></time>
+            <p class="text-left" class="blog_header">
+              <strong>
+                <a href="<%= article.url %>"><%= article.title %></a>
+              </strong>
             </p>
-
-            <%= article.summary(150, '...') %>
-            <p style ="text-align: center">
-              <a href="<%= article.url %>" style="color: #D40000;">Read more</a>
-            </p>
+            <div>
+              <%= article.summary(150, '...') %>
+              <a href="<%= article.url %>" style="color: #FF7722; padding-top: 0px;">Read more</a>
+            </div>
           </article>
         <% end %>
       </div>

--- a/source/news.html.erb
+++ b/source/news.html.erb
@@ -2,23 +2,36 @@
 title: Cornerstone | News
 ---
 <div class="blog container" id="blog">
-  <h2>News and Updates from Cornerstone</h2>
-  <div class="row">
-      <% blog.articles[0...4].each do |article| %>
-        <article class="col-sm-12 col-md-6" style="padding-right: 2em;">
-          <h3 class="blog_header">
-            <a href="<%= article.url %>"><%= article.title %></a>
-          </h3>
-          <p  style="text-align: center;">
-            <time><%= article.date.strftime('%b %e %Y') %></time>
-          </p>
+  <div class="blog_column col-sm-12 col-md-8">
+    <h2>News and Updates from Cornerstone</h2>
+    <div class="row">
+        <% blog.articles[0...4].each do |article| %>
+          <article class="col-sm-12" style="padding-right: 2em;">
+            <h3 class="blog_header">
+              <a href="<%= article.url %>"><%= article.title %></a>
+            </h3>
+            <p  style="text-align: center;">
+              <time><%= article.date.strftime('%b %e %Y') %></time>
+            </p>
 
-          <%= article.summary(500, '...') %>
-          <p style ="text-align: center">
-            <a href="<%= article.url %>" style="color: #D40000;">Read more</a>
-          </p>
-        </article>
-      <% end %>
-    </div>
+            <%= article.summary(750, '...') %>
+            <p style ="text-align: center">
+              <a href="<%= article.url %>" style="color: #D40000;">Read more</a>
+            </p>
+          </article>
+        <% end %>
+      </div>
+  </div>
+  <div class="press_release_column col-sm-12 col-md-4">
+    <h2>Press Releases</h2>
+    <h4>Fake Presser #1</h4>
+    <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."</p>
+    <a href="" style="color: #D40000;">Read more</a>
+    <h4>Fake Presser 2</h4>
+    <p>Kathy Ireland Video</p>
+    <a href="" style="color: #D40000;">Read more</a>
+    <h4>Fake Presser #3</h4>
+    <p>More amazing stuff about us...</p>
+    <a href="" style="color: #D40000;">Read more</a>
   </div>
 </div>

--- a/source/news.html.erb
+++ b/source/news.html.erb
@@ -26,7 +26,7 @@ title: Cornerstone | News
     <h3 class="text-center">PRESS RELEASES</h3>
     <div class="row">
         <% blog('press').articles[0...4].each do |article| %>
-          <article class="col-sm-12" style="padding-right: 2em;">
+          <article class="col-sm-12 press_release_column--article" style="padding-right: 2em;">
             <p class="text-left" class="blog_header">
               <strong>
                 <a href="<%= article.url %>"><%= article.title %></a>

--- a/source/news.html.erb
+++ b/source/news.html.erb
@@ -5,7 +5,7 @@ title: Cornerstone | News
   <div class="blog_column col-sm-12 col-md-8">
     <h2>News and Updates from Cornerstone</h2>
     <div class="row">
-        <% blog.articles[0...4].each do |article| %>
+        <% blog('blog').articles[0...4].each do |article| %>
           <article class="col-sm-12" style="padding-right: 2em;">
             <h3 class="blog_header">
               <a href="<%= article.url %>"><%= article.title %></a>
@@ -24,14 +24,22 @@ title: Cornerstone | News
   </div>
   <div class="press_release_column col-sm-12 col-md-4">
     <h2>Press Releases</h2>
-    <h4>Fake Presser #1</h4>
-    <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."</p>
-    <a href="" style="color: #D40000;">Read more</a>
-    <h4>Fake Presser 2</h4>
-    <p>Kathy Ireland Video</p>
-    <a href="" style="color: #D40000;">Read more</a>
-    <h4>Fake Presser #3</h4>
-    <p>More amazing stuff about us...</p>
-    <a href="" style="color: #D40000;">Read more</a>
+    <div class="row">
+        <% blog('press').articles[0...4].each do |article| %>
+          <article class="col-sm-12" style="padding-right: 2em;">
+            <h3 class="blog_header">
+              <a href="<%= article.url %>"><%= article.title %></a>
+            </h3>
+            <p  style="text-align: center;">
+              <time><%= article.date.strftime('%b %e %Y') %></time>
+            </p>
+
+            <%= article.summary(150, '...') %>
+            <p style ="text-align: center">
+              <a href="<%= article.url %>" style="color: #D40000;">Read more</a>
+            </p>
+          </article>
+        <% end %>
+      </div>
   </div>
 </div>

--- a/source/press/2016-10-16-Cornerstone-Management-Resource-Systems-promotes-Carl-Thoresen,-Ph.D.,-to-President.html.erb
+++ b/source/press/2016-10-16-Cornerstone-Management-Resource-Systems-promotes-Carl-Thoresen,-Ph.D.,-to-President.html.erb
@@ -1,0 +1,28 @@
+---
+title: Cornerstone Management Resource Systems promotes Carl Thoresen, Ph.D., to President
+date: 2016-10-16 20:46 UTC
+author: Kim M. Catania
+location: CARNEGIE, Pa.
+category: test
+tags: Cornerstone, Carl Thorensen
+---
+
+<p>
+  <em><%= current_page.data.location %>, <%= current_page.date.strftime('%b %e %Y') %></em> - Cornerstone Management Resource Systems Announces New President Carl Thoresen, Ph.D., Announced as New President
+</p>
+<p>
+  Cornerstone Management Resource Systems, which specializes in experiential Leadership Development programs, announced the appointment of Carl Thoresen, Ph.D., to President. In this role, Dr. Thoresen will be primarily responsible for content development that assists current and future leaders to build and extend their management skills. In addition to overseeing the implementation of all Task-Based Assessment Centers, Dr. Thoresen warrants that the content and delivery of all Cornerstone programs meet the highest professional and ethical standards.
+</p>
+<p>
+  “Carl’s research-oriented perspective to the design and implementation of Cornerstone’s unique methodology is instrumental in customizing our programs,” stated Joe Thoresen, Cornerstone Founder.
+</p>
+<p>
+  As an internationally recognized author and researcher on employee selection, job attitudes, employee assessment, and the role of personality in job performance, Carl’s expertise in training and in-depth experiences in test development are critical to each program’s success.
+</p>
+<p>
+  Carl joined the Cornerstone team after working as Assistant Professor of industrial/organizational psychology at Tulane University. He has extensive training and experience in test development and validation. After graduating from Northwestern University, Carl earned an M.S. degree in organizational behavior from Cornell University. He later completed his Ph.D. in human resource management with a minor concentration in personality and social psychology at the University of Iowa.
+</p>
+<p>
+About Cornerstone Management Resource Systems
+Founded in 1983, Cornerstone custom-designs and implements Leadership Development programs for life science organizations that include sales, marketing, managed markets and medical affairs. The Cornerstone process assists in the identification of potential leaders, provides realistic job previews to boost skills, and affords the opportunity to demonstrate readiness before promotion. For more information, visit <a href="www.leadwithcornerstone.com">www.leadwithcornerstone.com</a>
+</p>

--- a/source/press/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
+++ b/source/press/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
@@ -31,7 +31,7 @@ tags: Cornerstone, Carl Thorensen, Joe Thorensen, Kathy Ireland
   JL Haber, Vice President of Programming for Worldwide Business with kathy ireland®, added. “Cornerstone is providing a much needed and time-tested solution to develop tomorrow’s great business leaders. It is a pleasure to feature them on the show! ”
 </p>
 <p>
-  For more information, visit www.leadwithcornerstone.com and tune in to [Fox Business Network](http://www.foxbusiness.com/channel-finder.html) as sponsored programming on Saturday, November 26, 2016 at 4:30pm EST and [Bloomberg International](http://www.bloomberg.com/tv/schedule/europe/) at 10:00am D.F. and 2:30pm HKT on Sunday November 27, 2016.
+  For more information, visit www.leadwithcornerstone.com and tune in to <a href="http://www.foxbusiness.com/channel-finder.html">Fox Business Network</a> as sponsored programming on Saturday, November 26, 2016 at 4:30pm EST and <a href="http://www.bloomberg.com/tv/schedule/europe/">Bloomberg International</a> at 10:00am D.F. and 2:30pm HKT on Sunday November 27, 2016.
 </p>
 <p>
   About Worldwide Business with kathy ireland®
@@ -40,5 +40,5 @@ tags: Cornerstone, Carl Thorensen, Joe Thorensen, Kathy Ireland
   Worldwide Business with kathy ireland® is a weekly business television program featuring real world insights from corporate executives from all over the globe which can be viewed on Fox Business Network as part of their sponsored programming lineup, as well as internationally to over 50 countries on Bloomberg International. 
 </p>
 <p>
-  Visit [www.tvwwb.com](http://www.tvwwb.com/) for detailed airing schedules or check local listings.
+  Visit <a href="http://www.tvwwb.com/">www.tvwwb.com</a> for detailed airing schedules or check local listings.
 </p>

--- a/source/press/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
+++ b/source/press/2016-11-09-Worldwide-Business-with-kathy-ireland®-Explores-Cornerstone’s-Approach-to-Building-Great-Business-Leaders.html.erb
@@ -1,0 +1,44 @@
+---
+title: Worldwide Business with kathy ireland® Explores Cornerstone’s Approach to Building Great Business Leaders
+date: 2016-11-09 20:46 UTC
+author: Cornerstone Management Resourse Systems
+location: CARNEGIE, Pa.
+category: Press Releases
+tags: Cornerstone, Carl Thorensen, Joe Thorensen, Kathy Ireland
+---
+
+<p>
+  <em><%= current_page.data.location %>, <%= current_page.date.strftime('%b %e %Y') %></em> - Worldwide Business with kathy ireland® Explores Cornerstone’s Approach to Building Great Business Leaders
+</p>
+<p>
+  Tune in to Fox Business Network as sponsored programming on Saturday, November 26, 2016 and Bloomberg International on Sunday, November 27, 2016, 2016. See market-by-market listings below.
+  Los Angeles, CA – November 23, 2016 — Worldwide Business with kathy ireland® announces an exclusive story featuring, Cornerstone, a company creating effective, research-based solutions to identify and prepare top talent to become effective leaders and managers. 
+</p>
+<p>
+  Cornerstone President, Joe Thoresen and Vice President, Carl Thoresen will explain how they are preparing individuals for their future roles in leadership. 
+  Carl Thoresen says, “The fundamental challenge stems from the fact that when we move people from typically individual roles into frontline leadership roles, especially for the first time, in their careers, we don’t really have a basis for observing how effectively they will perform in that function. So what results is the need to use some sort of interim assessment. We might for example look at performance in a current role or current job, we might have some other methodology that involves some form of testing, etc.”
+</p>
+<p>
+  The company, founded in 1983, was created so that those individuals that are being placed in a position of power have the resources to both learn the role, and learn how to be an effective leader and manager. Cornerstone provides a wide range of e-learning material that helps those individuals go from a place of individual job skills to being able to lead a team and step into the leadership role effectively and efficiently.
+</p>
+<p>
+  “Before people are promoted from individual contributor jobs into first level management positions, they must demonstrate competence handling the key tasks they will have to effectively handle as new managers and leaders,” says Carl Thoresen.  “Performance on simulations, carefully designed to reflect the content of specific first-level management positions and supported with objective measurement techniques, provide the information necessary to make these evaluations. Based on their simulation performance, participants are evaluated on their readiness for promotion. This methodology has been designed to be naturally diagnostic and developmental. When people are evaluated as ‘Not Ready’, they are told what specific tasks/responsibilities they must perform more effectively and provided with developmental ideas and strategies to develop necessary skills.”
+</p>
+<p>
+  Joe Thoresen added, “We provide clients with the option of using a methodology that is much more powerful than the aptitude-based techniques they have used in the past. Although application of our methodology may initially be more complex and expensive than traditional approaches, its accuracy and utility is much more compatible with the short and long term importance of managerial and leadership performance. When promoted, new managers have already demonstrated effectiveness handling key managerial tasks and do not have to engage in on-the-job training to develop the basic skills necessary for success.”
+</p>
+<p>
+  JL Haber, Vice President of Programming for Worldwide Business with kathy ireland®, added. “Cornerstone is providing a much needed and time-tested solution to develop tomorrow’s great business leaders. It is a pleasure to feature them on the show! ”
+</p>
+<p>
+  For more information, visit www.leadwithcornerstone.com and tune in to [Fox Business Network](http://www.foxbusiness.com/channel-finder.html) as sponsored programming on Saturday, November 26, 2016 at 4:30pm EST and [Bloomberg International](http://www.bloomberg.com/tv/schedule/europe/) at 10:00am D.F. and 2:30pm HKT on Sunday November 27, 2016.
+</p>
+<p>
+  About Worldwide Business with kathy ireland®
+</p>
+<p>
+  Worldwide Business with kathy ireland® is a weekly business television program featuring real world insights from corporate executives from all over the globe which can be viewed on Fox Business Network as part of their sponsored programming lineup, as well as internationally to over 50 countries on Bloomberg International. 
+</p>
+<p>
+  Visit [www.tvwwb.com](http://www.tvwwb.com/) for detailed airing schedules or check local listings.
+</p>

--- a/source/press/2016-11-09-test-press-post-1.html.markdown
+++ b/source/press/2016-11-09-test-press-post-1.html.markdown
@@ -1,0 +1,28 @@
+---
+blog: press
+title: Dummy Press Post #1
+date: 2016-11-09 20:46 UTC
+author: Gary A. Newsome
+category: test
+tags: web development, life, business, love, hate
+---
+
+The standard Lorem Ipsum passage, used since the 1500s
+
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+Section 1.10.32 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
+
+1914 translation by H. Rackham
+
+"But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?"
+
+Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat."
+
+1914 translation by H. Rackham
+
+"On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains."

--- a/source/press/2016-11-09-test-press-post-2.html.markdown
+++ b/source/press/2016-11-09-test-press-post-2.html.markdown
@@ -1,0 +1,28 @@
+---
+blog: press
+title: Dummy Press Post #1
+date: 2016-11-09 20:46 UTC
+author: Gary A. Newsome
+category: test
+tags: web development, life, business, love, hate
+---
+
+The standard Lorem Ipsum passage, used since the 1500s
+
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+Section 1.10.32 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
+
+1914 translation by H. Rackham
+
+"But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?"
+
+Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat."
+
+1914 translation by H. Rackham
+
+"On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains."

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -349,6 +349,13 @@ i.red{
   h1, h2, h3, h4, h5, h6 {
     text-align: center;
   }
+  h2 {
+    // color: #0D1534;
+  }
+  h3 a{
+    // color: #0D1534;
+    color: lighten(#0D1534, 20%);
+  }
   a {
     color: #0D1534;
   }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -346,16 +346,6 @@ i.red{
 .blog {
   padding: 2em 0em 2em 0em;
   min-height: 480px;
-  h1, h2, h3, h4, h5, h6 {
-    text-align: center;
-  }
-  h2 {
-    // color: #0D1534;
-  }
-  h3 a{
-    // color: #0D1534;
-    color: lighten(#0D1534, 20%);
-  }
   a {
     color: #0D1534;
   }
@@ -364,7 +354,8 @@ i.red{
   }
 }
 
-.blog_header {
-  padding-top: 1em;
-  text-align: center;
+.press_release_column {
+  article {
+    padding: 1em 0em 1em 0em;
+  }
 }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -354,8 +354,6 @@ i.red{
   }
 }
 
-.press_release_column {
-  article {
-    padding: 1em 0em 1em 0em;
-  }
+.press_release_column--article {
+  padding: 1em 0em 1em 0em;
 }


### PR DESCRIPTION
###### Add Press Release section to the Blog

Added a press release section to the blog. Limited `News` to 8 columns on the left, and allocated the remaining 4 to the `Press` section. 

Made the `Press` section a second middle man blog. The news section is named `blog`, and the press release section is named `press`