### PR TITLE
Fix padding issue

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -358,6 +358,10 @@ i.red{
   padding-bottom: 2em;
 }
 
-.news {
+.blog_column {
+  padding-top: 2em;
+}
+
+.press_release_column {
   padding-top: 2em;
 }


### PR DESCRIPTION
###### Fix Padding Issue

In the process of fixing the weird padding issue on the individual `news` and `press` posts, I apparently moved the problem to the main `news` page. Padding was adjusted to the header sits flush against the top in both views.

###### Needs
- CR / approval
- `rake publish`